### PR TITLE
Upgrading calliope to 0.6.7

### DIFF
--- a/calliope_app/api/fixtures/admin_run_parameter.json
+++ b/calliope_app/api/fixtures/admin_run_parameter.json
@@ -8,7 +8,7 @@
       "can_evolve": "False",
       "name": "calliope_version",
       "pretty_name": "Calliope version",
-      "default_value": "0.6.6",
+      "default_value": "0.6.7",
       "description": "Calliope framework version this model is intended for",
       "choices": "[]"
     }

--- a/calliope_app/api/fixtures/sample_scenario_param.json
+++ b/calliope_app/api/fixtures/sample_scenario_param.json
@@ -15,7 +15,7 @@
     "fields": {
       "scenario_id": "1",
       "run_parameter_id": "1",
-      "value": "0.6.6",
+      "value": "0.6.7",
       "model_id": "1"
     }
   },

--- a/calliope_app/client/templates/base.html
+++ b/calliope_app/client/templates/base.html
@@ -215,7 +215,7 @@
 				<img src="{% static 'images/calliope_logo.png' %}" height="36px" style="margin-top:-4px" />
 			</a>
 			&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-	      	<a href="https://calliope.readthedocs.io/en/v0.6.6-post1/" target="_blank"><b>Calliope {% trans "Documentation" %} 0.6.6</b></a>
+	      	<a href="https://calliope.readthedocs.io/en/v0.6.7/" target="_blank"><b>Calliope {% trans "Documentation" %} 0.6.7</b></a>
 	      	<hr>
 
 	      	<!-- Contextual Content -->

--- a/calliope_app/client/templates/registration/login.html
+++ b/calliope_app/client/templates/registration/login.html
@@ -55,7 +55,7 @@
 					<img src="{% static 'images/calliope_logo.png' %}" height="36px" style="margin-top:-4px" />
 				</a>
 				&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-		      	<a href="https://calliope.readthedocs.io/en/v0.6.6-post1/" target="_blank"><b>Calliope {% trans "Documentation" %} 0.6.6</b></a>
+		      	<a href="https://calliope.readthedocs.io/en/v0.6.7/" target="_blank"><b>Calliope {% trans "Documentation" %} 0.6.7</b></a>
 				<br><br>
 			</div>
 		</div>

--- a/calliope_app/requirements.txt
+++ b/calliope_app/requirements.txt
@@ -1,4 +1,4 @@
-calliope==0.6.6-post1
+calliope==0.6.7
 click==7.1.2
 django==2.2.24
 django-environ>=0.4.5
@@ -11,7 +11,7 @@ pyyaml==5.4
 pyutilib==6.0.0
 django-modeltranslation==0.14.2
 gunicorn==19.9.0
-pyomo==5.7
+pyomo==6.0
 amqp==2.6.1
 vine==1.3.0
 nrel-pysam==2.1.5.dev3

--- a/docs/_sources/developer-guide.rst.txt
+++ b/docs/_sources/developer-guide.rst.txt
@@ -128,8 +128,8 @@ Calliope References
 Official Documentation
 ~~~~~~~~~~~~~~~~~~~~~~
 
-This web application is built on top of ``Calliope - v0.6.6`` for now, the official documentation is linked here 
-https://calliope.readthedocs.io/en/v0.6.6-post1/.
+This web application is built on top of ``Calliope - v0.6.7`` for now, the official documentation is linked here 
+https://calliope.readthedocs.io/en/v0.6.7/.
 
 
 Example Models

--- a/docs/_sources/optimization-solvers.rst.txt
+++ b/docs/_sources/optimization-solvers.rst.txt
@@ -38,7 +38,7 @@ to solve Calliope models with fast speed and large memory in compute node.
 More Choice
 -----------
 In behind, Calliope interfaces to `Pyomo <http://www.pyomo.org/>`_  - a Python-based, open-source optimization modeling language with 
-a diverse set of optimization capabilities. With the `API interface <https://calliope.readthedocs.io/en/v0.6.6-post1/api/api.html#api-backend-interface>`_ 
+a diverse set of optimization capabilities. With the `API interface <https://calliope.readthedocs.io/en/v0.6.7/api/api.html#api-backend-interface>`_ 
 provided by Calliope, you can specify the customized solver options.
 
 For more solver choice, please refer to `specifying-custom-solver-options 

--- a/docs/_sources/release-notes.rst.txt
+++ b/docs/_sources/release-notes.rst.txt
@@ -10,7 +10,7 @@ release, please observe the release notes below.
 
 Release Notes:
 
-* Support Calliope version 0.6.6.
+* Support Calliope version 0.6.7.
 * Support solvers - GLPK and FICO XPRESS.
 * Model user sign on and authentication.
 * Visualized Calliope model configuration, build and run.

--- a/docs/developer-guide.html
+++ b/docs/developer-guide.html
@@ -138,8 +138,8 @@ The link below is the address of Flower dashboard for dev.</p>
 <h2>Calliope References<a class="headerlink" href="#calliope-references" title="Permalink to this headline">¶</a></h2>
 <div class="section" id="official-documentation">
 <h3>Official Documentation<a class="headerlink" href="#official-documentation" title="Permalink to this headline">¶</a></h3>
-<p>This web application is built on top of <code class="docutils literal notranslate"><span class="pre">Calliope</span> <span class="pre">-</span> <span class="pre">v0.6.6</span></code> for now, the official documentation is linked here
-<a class="reference external" href="https://calliope.readthedocs.io/en/v0.6.6-post1/">https://calliope.readthedocs.io/en/v0.6.6-post1/</a>.</p>
+<p>This web application is built on top of <code class="docutils literal notranslate"><span class="pre">Calliope</span> <span class="pre">-</span> <span class="pre">v0.6.7</span></code> for now, the official documentation is linked here
+<a class="reference external" href="https://calliope.readthedocs.io/en/v0.6.7/">https://calliope.readthedocs.io/en/v0.6.7/</a>.</p>
 </div>
 <div class="section" id="example-models">
 <h3>Example Models<a class="headerlink" href="#example-models" title="Permalink to this headline">¶</a></h3>

--- a/docs/optimization-solvers.html
+++ b/docs/optimization-solvers.html
@@ -65,7 +65,7 @@ to solve Calliope models with fast speed and large memory in compute node.</p>
 <div class="section" id="more-choice">
 <h2>More Choice<a class="headerlink" href="#more-choice" title="Permalink to this headline">¶</a></h2>
 <p>In behind, Calliope interfaces to <a class="reference external" href="http://www.pyomo.org/">Pyomo</a>  - a Python-based, open-source optimization modeling language with
-a diverse set of optimization capabilities. With the <a class="reference external" href="https://calliope.readthedocs.io/en/v0.6.6-post1/api/api.html#api-backend-interface">API interface</a>
+a diverse set of optimization capabilities. With the <a class="reference external" href="https://calliope.readthedocs.io/en/v0.6.7/api/api.html#api-backend-interface">API interface</a>
 provided by Calliope, you can specify the customized solver options.</p>
 <p>For more solver choice, please refer to <a class="reference external" href="https://calliope.readthedocs.io/en/stable/user/advanced_features.html#specifying-custom-solver-options">specifying-custom-solver-options</a></p>
 <p>Refer to <a class="reference external" href="https://calliope.readthedocs.io/en/stable/user/troubleshooting.html#influence-of-solver-choice-on-speed">influence-of-solver-choice-on-speed</a>

--- a/docs/release-notes.html
+++ b/docs/release-notes.html
@@ -41,7 +41,7 @@ release, please observe the release notes below.</p>
 <h2>0.1.0<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h2>
 <p>Release Notes:</p>
 <ul class="simple">
-<li><p>Support Calliope version 0.6.6.</p></li>
+<li><p>Support Calliope version 0.6.7.</p></li>
 <li><p>Support solvers - GLPK and FICO XPRESS.</p></li>
 <li><p>Model user sign on and authentication.</p></li>
 <li><p>Visualized Calliope model configuration, build and run.</p></li>

--- a/docs/sources/developer-guide.rst
+++ b/docs/sources/developer-guide.rst
@@ -128,8 +128,8 @@ Calliope References
 Official Documentation
 ~~~~~~~~~~~~~~~~~~~~~~
 
-This web application is built on top of ``Calliope - v0.6.6`` for now, the official documentation is linked here 
-https://calliope.readthedocs.io/en/v0.6.6-post1/.
+This web application is built on top of ``Calliope - v0.6.7`` for now, the official documentation is linked here 
+https://calliope.readthedocs.io/en/v0.6.7/.
 
 
 Example Models

--- a/docs/sources/optimization-solvers.rst
+++ b/docs/sources/optimization-solvers.rst
@@ -38,7 +38,7 @@ to solve Calliope models with fast speed and large memory in compute node.
 More Choice
 -----------
 In behind, Calliope interfaces to `Pyomo <http://www.pyomo.org/>`_  - a Python-based, open-source optimization modeling language with 
-a diverse set of optimization capabilities. With the `API interface <https://calliope.readthedocs.io/en/v0.6.6-post1/api/api.html#api-backend-interface>`_ 
+a diverse set of optimization capabilities. With the `API interface <https://calliope.readthedocs.io/en/v0.6.7/api/api.html#api-backend-interface>`_ 
 provided by Calliope, you can specify the customized solver options.
 
 For more solver choice, please refer to `specifying-custom-solver-options 

--- a/docs/sources/release-notes.rst
+++ b/docs/sources/release-notes.rst
@@ -10,7 +10,7 @@ release, please observe the release notes below.
 
 Release Notes:
 
-* Support Calliope version 0.6.6.
+* Support Calliope version 0.6.7.
 * Support solvers - GLPK and FICO XPRESS.
 * Model user sign on and authentication.
 * Visualized Calliope model configuration, build and run.


### PR DESCRIPTION
Upgrading calliope to version 0.6.7 which includes an upgrade to pyomo version 6.0. Updating all documentation links and references to use the new calliope version.