### PR TITLE
Fixing bug in empty template CSVs

### DIFF
--- a/calliope_app/client/templates/share.html
+++ b/calliope_app/client/templates/share.html
@@ -56,9 +56,9 @@
 			  templateSelection: formatState
 			});
 		</script>
-		<input id="remove_collaborator_btn" style="width:33%;float:left;border-color:black" class="btn btn-outline-danger" type="submit" value="Remove">
-		<input id="add_collaborator_btn_view_only" style="width:33%;float:left;background-color:yellow;border-color:black" class="btn btn-warning" type="submit" data-collaborator_can_edit=0 value="View Only">
-		<input id="add_collaborator_btn" style="width:33%" class="btn btn-success" type="submit" data-collaborator_can_edit=1 value="Can Edit">
+		<input id="remove_collaborator_btn" style="width:33%;float:left;border-color:black" class="btn btn-outline-danger" type="button" value="Remove">
+		<input id="add_collaborator_btn_view_only" style="width:33%;float:left;background-color:yellow;border-color:black" class="btn btn-warning" type="button" data-collaborator_can_edit=0 value="View Only">
+		<input id="add_collaborator_btn" style="width:33%" class="btn btn-success" type="button" data-collaborator_can_edit=1 value="Can Edit">
 		<br><br><br>
 	</div>
 	<div class="col-4"></div>


### PR DESCRIPTION
Fixing bug where the essential tech/loc_tech fields were not showing up as columns in CSV templates from empty models.

Also potentially fixing bug causing model sharing to fail in Firefox.