### PR TITLE
Adding fix to account for reverselookup error

### DIFF
--- a/calliope_app/account/urls.py
+++ b/calliope_app/account/urls.py
@@ -47,7 +47,7 @@ urlpatterns = [
     url(
         r'^reset/\
         (?P<uidb64>[0-9A-Za-z_\-]+)/\
-        (?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
+        (?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,40})/$',
         auth_views.PasswordResetConfirmView.as_view(
             template_name='registration/pw_reset_confirm.html'
         ),


### PR DESCRIPTION
Adding fix to allow for larger CSRF token to prevent ReverseLookupError on password reset

See regex answers at bottom of: https://stackoverflow.com/questions/28418233/noreversematch-at-rest-auth-password-reset