### PR TITLE
Refactoring YAML export code to directly write dicts

### DIFF
--- a/calliope_app/api/calliope_utils.py
+++ b/calliope_app/api/calliope_utils.py
@@ -8,6 +8,7 @@ import yaml
 import shutil
 from calliope import Model as CalliopeModel
 import pandas as pd
+import json
 
 from api.models.configuration import Scenario_Param, Scenario_Loc_Tech, \
     Location, Tech_Param, Loc_Tech_Param, Loc_Tech
@@ -18,37 +19,29 @@ def get_model_yaml_set(scenario_id, year):
     params = Scenario_Param.objects.filter(scenario_id=scenario_id,
                                            year__lte=year).order_by('-year')
     # Initialize the Return list
-    model_yaml_set = []
+    model_yaml_set = {}
     # There are no timeseries in Run Parameters
     is_timeseries = False
     # Tracks which parameters have already been set (prioritized by year)
     unique_params = []
     # Loop over Parameters
     for param in params:
-        unique_param = param.run_parameter.root+param.run_parameter.name
+        unique_param = (param.run_parameter.root+'.'+param.run_parameter.name)
 
         # NOTE: deprecated run parameter in the database
-        if unique_param == "runobjective_options":
+        if unique_param == "run.objective_options":
             continue
         
         if unique_param not in unique_params:
             # If parameter hasn't been set, add to Return List
             unique_params.append(unique_param)
-            if "." in param.run_parameter.root:
-                items = param.run_parameter.root.split(".")
-                param_list = items + [param.run_parameter.name, param.value]
-            else:
-                param_list = [
-                    param.run_parameter.root,
-                    param.run_parameter.name,
-                    param.value
-                ]
-            model_yaml_set.append((stringify(param_list), is_timeseries))
-    model_yaml_set += [('import||["techs.yaml","locations.yaml"]', False)]
+            param_list = unique_param.split('.')+[param.value]
+            dictify(model_yaml_set,param_list)
+    dictify(model_yaml_set,['import','["techs.yaml","locations.yaml"]'])
     return model_yaml_set
 
 
-def get_location_meta_yaml_set(scenario_id):
+def get_location_meta_yaml_set(scenario_id, existing = {}):
     """ Function pulls model locations from Database for YAML """
     loc_techs = Scenario_Loc_Tech.objects.filter(scenario_id=scenario_id)
     loc_ids = loc_techs.values_list('loc_tech__location_1',
@@ -57,7 +50,7 @@ def get_location_meta_yaml_set(scenario_id):
         [item for sublist in loc_ids for item in sublist])))
     locations = Location.objects.filter(id__in=loc_ids)
     # Initialize the Return list
-    location_coord_yaml_set = []
+    location_coord_yaml_set = existing
     # There are no timeseries in Location Coordinates
     is_timeseries = False
     # Loop over Parameters
@@ -66,13 +59,13 @@ def get_location_meta_yaml_set(scenario_id):
         coordinates = '{{"lat": {}, "lon": {}}}'.format(loc.latitude,
                                                         loc.longitude)
         param_list = ['locations', loc.name, 'coordinates', coordinates]
-        location_coord_yaml_set.append((stringify(param_list), is_timeseries))
+        dictify(location_coord_yaml_set,param_list)
         # Available Area
         if loc.available_area is None:
             continue
         param_list = ['locations', loc.name,
                       'available_area', loc.available_area]
-        location_coord_yaml_set.append((stringify(param_list), is_timeseries))
+        dictify(location_coord_yaml_set,param_list)
     return location_coord_yaml_set
 
 
@@ -84,7 +77,7 @@ def get_techs_yaml_set(scenario_id, year):
     parameters = Tech_Param.objects.filter(technology_id__in=tech_ids,
                                            year__lte=year).order_by('-year')
     # Initialize the Return list
-    techs_yaml_set = []
+    techs_yaml_set = {}
     # Loop over Technologies
     for tech_id in tech_ids:
         params = parameters.filter(technology_id=tech_id)
@@ -92,19 +85,21 @@ def get_techs_yaml_set(scenario_id, year):
         unique_params = []
         # Loop over Parameters
         for param in params:
-            unique_param = param.parameter.root + param.parameter.name
+            unique_param = (param.parameter.root+'.'+param.parameter.name)
             if unique_param not in unique_params:
                 # If parameter hasn't been set, add to Return List
                 unique_params.append(unique_param)
-                is_timeseries = param.timeseries
-                if '%' in param.parameter.units:  # Calliope in decimal format
+                if param.timeseries:
+                    value = "file={}--{}.csv:value".format(
+                                    param.technology.calliope_name, unique_param.replace('.','-'))
+                elif '%' in param.parameter.units:  # Calliope in decimal format
                     value = float(param.value) / 100
                 else:
                     value = param.value
-                param_list = ['techs', param.technology.calliope_name,
-                              param.parameter.root, param.parameter.name,
-                              value]
-                techs_yaml_set.append((stringify(param_list), is_timeseries))
+                param_list = ['techs', param.technology.calliope_name]+\
+                              unique_param.split('.')+\
+                              [value]
+                dictify(techs_yaml_set,param_list)
     return techs_yaml_set
 
 
@@ -117,7 +112,7 @@ def get_loc_techs_yaml_set(scenario_id, year):
     parameters = Loc_Tech_Param.objects.filter(
         loc_tech_id__in=loc_tech_ids, year__lte=year).order_by('-year')
     # Initialize the Return list
-    loc_techs_yaml_set = []
+    loc_techs_yaml_set = {}
     # Loop over Technologies
     for loc_tech_id in loc_tech_ids:
         loc_tech = Loc_Tech.objects.get(id=loc_tech_id)
@@ -132,36 +127,67 @@ def get_loc_techs_yaml_set(scenario_id, year):
         else:
             parent_type = 'locations'
             location = loc_tech.location_1.name
+        technology = loc_tech.technology.calliope_name
 
         if len(params) == 0:
-            is_timeseries = False
             param_list = [parent_type, location, 'techs',
-                          loc_tech.technology.calliope_name, '']
-            loc_techs_yaml_set.append((stringify(param_list), is_timeseries))
+                          technology, '']
+            dictify(loc_techs_yaml_set,param_list)
             continue
 
         # Tracks which parameters have already been set (prioritized by year)
         unique_params = []
         # Loop over Parameters
         for param in params:
-            unique_param = param.parameter.root + param.parameter.name
+            unique_param = (param.parameter.root+'.'+param.parameter.name)
             if unique_param not in unique_params:
                 # If parameter hasn't been set, add to Return List
                 unique_params.append(unique_param)
-                is_timeseries = param.timeseries
-                if '%' in param.parameter.units:  # Calliope in decimal format
+                if param.timeseries:
+                    value = "file={}--{}--{}.csv:value".format(
+                                    location, technology, unique_param.replace('.','-'))
+                elif '%' in param.parameter.units:  # Calliope in decimal format
                     value = float(param.value) / 100
                 else:
                     value = param.value
+                    
                 param_list = [parent_type, location, 'techs',
-                              param.loc_tech.technology.calliope_name,
-                              param.parameter.root,
-                              param.parameter.name,
-                              value]
-                loc_techs_yaml_set.append((stringify(param_list),
-                                           is_timeseries))
+                              param.loc_tech.technology.calliope_name]+\
+                              unique_param.split('.')+\
+                              [value]
+                dictify(loc_techs_yaml_set,param_list)
     return loc_techs_yaml_set
 
+def dictify(target, arr):
+    level = target
+    
+    # Build the nested dict structure (if neccessary) by adding any
+    # nested keys in the list before the final key/value pair
+    keys = [k for k in arr[:-1] if k != '']
+    if len(keys) > 1:
+        for key in keys[:-1]:
+            if key not in level.keys():
+                level[key] = {}
+            level = level[key]
+
+    # Handle blank, T/F, float, and JSON string values
+    if arr[-1] == "":
+            level[keys[-1]] = None
+    elif arr[-1] == 'True':
+            level[keys[-1]] = True
+    elif arr[-1] == 'False':
+            level[keys[-1]] = False
+    else:
+        try:
+            string = arr[-1].replace(", ", ",")
+            for char in ['\'', '“', '”', '‘', '’']:
+                string = string.replace(char, '\"')
+            level[keys[-1]] = json.loads(string)
+        except Exception:
+            try:
+                level[keys[-1]] = float(arr[-1])
+            except ValueError:
+                level[keys[-1]] = arr[-1]
 
 def stringify(param_list):
     param_list = [str(x) for x in param_list]

--- a/calliope_app/api/tasks.py
+++ b/calliope_app/api/tasks.py
@@ -228,21 +228,17 @@ def build_model_yaml(scenario_id, start_date, inputs_path):
     model_yaml_set = get_model_yaml_set(scenario_id, year)
     with open(os.path.join(inputs_path, "model.yaml"), 'w') as outfile:
         yaml.dump(model_yaml_set, outfile, default_flow_style=False)
-    #list_to_yaml(model_yaml_set, os.path.join(inputs_path, "model.yaml"))
 
     # techs.yaml
     techs_yaml_set = get_techs_yaml_set(scenario_id, year)
     with open(os.path.join(inputs_path, "techs.yaml"), 'w') as outfile:
         yaml.dump(techs_yaml_set, outfile, default_flow_style=False)
-    #list_to_yaml(techs_yaml_set, os.path.join(inputs_path, "techs.yaml"))
 
     # locations.yaml
     loc_techs_yaml_set = get_loc_techs_yaml_set(scenario_id, year)
     location_yaml_set = get_location_meta_yaml_set(scenario_id, loc_techs_yaml_set)
     with open(os.path.join(inputs_path, "locations.yaml"), 'w') as outfile:
         yaml.dump(location_yaml_set, outfile, default_flow_style=False)
-    #list_to_yaml(loc_techs_yaml_set + location_coord_yaml_set,
-    #             os.path.join(inputs_path, "locations.yaml"))
 
 
 def build_model_csv(model, scenario, start_date, end_date, inputs_path, timesteps):

--- a/calliope_app/api/tasks.py
+++ b/calliope_app/api/tasks.py
@@ -9,6 +9,7 @@ import botocore
 import pandas as pd
 import numpy as np
 import datetime
+import yaml
 from dateutil.parser import parse as date_parse
 
 from celery import Task
@@ -225,17 +226,23 @@ def build_model_yaml(scenario_id, start_date, inputs_path):
 
     # model.yaml
     model_yaml_set = get_model_yaml_set(scenario_id, year)
-    list_to_yaml(model_yaml_set, os.path.join(inputs_path, "model.yaml"))
+    with open(os.path.join(inputs_path, "model.yaml"), 'w') as outfile:
+        yaml.dump(model_yaml_set, outfile, default_flow_style=False)
+    #list_to_yaml(model_yaml_set, os.path.join(inputs_path, "model.yaml"))
 
     # techs.yaml
     techs_yaml_set = get_techs_yaml_set(scenario_id, year)
-    list_to_yaml(techs_yaml_set, os.path.join(inputs_path, "techs.yaml"))
+    with open(os.path.join(inputs_path, "techs.yaml"), 'w') as outfile:
+        yaml.dump(techs_yaml_set, outfile, default_flow_style=False)
+    #list_to_yaml(techs_yaml_set, os.path.join(inputs_path, "techs.yaml"))
 
     # locations.yaml
     loc_techs_yaml_set = get_loc_techs_yaml_set(scenario_id, year)
-    location_coord_yaml_set = get_location_meta_yaml_set(scenario_id)
-    list_to_yaml(loc_techs_yaml_set + location_coord_yaml_set,
-                 os.path.join(inputs_path, "locations.yaml"))
+    location_yaml_set = get_location_meta_yaml_set(scenario_id, loc_techs_yaml_set)
+    with open(os.path.join(inputs_path, "locations.yaml"), 'w') as outfile:
+        yaml.dump(location_yaml_set, outfile, default_flow_style=False)
+    #list_to_yaml(loc_techs_yaml_set + location_coord_yaml_set,
+    #             os.path.join(inputs_path, "locations.yaml"))
 
 
 def build_model_csv(model, scenario, start_date, end_date, inputs_path, timesteps):
@@ -254,27 +261,27 @@ def build_model_csv(model, scenario, start_date, end_date, inputs_path, timestep
     for ts in list(tech_ts) + list(loc_tech_ts):
         timeseries_meta_id = ts.timeseries_meta_id
         parameter_name = ts.parameter.name
-        try:
+        parameter_root = ts.parameter.root.replace('.','-')
+        if ts in loc_tech_ts:
             location_1_name = ts.loc_tech.location_1.name
             technology_name = ts.loc_tech.technology.calliope_name
             if not ts.loc_tech.location_2:
                 filename = os.path.join(
-                    inputs_path, "{}--{}--{}.csv".format(
+                    inputs_path, "{}--{}--{}-{}.csv".format(
                         location_1_name, technology_name,
-                        parameter_name))
+                        parameter_root, parameter_name))
             else:
                 location_2_name = ts.loc_tech.location_2.name
                 filename = os.path.join(inputs_path,
-                                        "{},{}--{}--{}.csv".format(
+                                        "{},{}--{}--{}-{}.csv".format(
                                             location_1_name, location_2_name,
-                                            technology_name,
+                                            technology_name, parameter_root,
                                             parameter_name))
-        except Exception as e:
-            print(e)
+        elif ts in tech_ts:
             technology_name = ts.technology.calliope_name
             filename = os.path.join(
-                inputs_path, "{}--{}.csv".format(
-                    technology_name, parameter_name))
+                inputs_path, "{}--{}-{}.csv".format(
+                    technology_name, parameter_root, parameter_name))
         timeseries_meta = Timeseries_Meta.objects.filter(
             id=timeseries_meta_id).first()
         if timeseries_meta is not None:

--- a/calliope_app/api/utils.py
+++ b/calliope_app/api/utils.py
@@ -119,6 +119,7 @@ def dictfetchall(cursor):
 def list_to_yaml(table_list, filename):
     """
     Convert a list of strings to YAML file format
+    DEPRECATED: The YAML creation code was refactored to write directly to a dict
     """
 
     X = [x[0].split('||') for x in table_list]


### PR DESCRIPTION
Refactored the YAML export code to directly write a dict during the parameter reading routines rather than write the lists and call list_to_yaml. Goal is to increase readability and flexibility to accommodate other root/dict formats

Additionally, fixed potential bug introduced with cost classes by adding parameter root to the CSV file names. Slightly refactored CSV export code to remove Exception try catch and explicitly check for Technology vs Loc_Tech when choosing CSV names.