### PR TITLE
Fix docker vulnerabilities

### DIFF
--- a/calliope_app/compose/Dockerfile
+++ b/calliope_app/compose/Dockerfile
@@ -42,7 +42,9 @@ COPY requirements.txt requirements-dev.txt /www/
 RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
 RUN pip install -r requirements-dev.txt
-RUN pip install psycopg2-binary
+
+# Install calliope without dependencies, as already installed in requirements
+RUN pip install calliope==0.6.7 --no-deps
 
 COPY . .
 

--- a/calliope_app/compose/Dockerfile
+++ b/calliope_app/compose/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update -y --fix-missing \
     && apt-get install -y --no-install-recommends \
     build-essential \
     python3-dev \
-    python3-pip \
     libgmp3-dev \
     libz-dev \
     libreadline-dev \
@@ -45,6 +44,7 @@ RUN pip install -r requirements-dev.txt
 
 # Install calliope without dependencies, as already installed in requirements
 RUN pip install calliope==0.6.7 --no-deps
+RUN pip install flower>=1.1.0
 
 COPY . .
 

--- a/calliope_app/compose/run-celery-flower.sh
+++ b/calliope_app/compose/run-celery-flower.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-celery flower -A calliope_app --port=5555
+celery -A calliope_app flower --port=5555

--- a/calliope_app/compose/run-long-worker.sh
+++ b/calliope_app/compose/run-long-worker.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-celery worker -n long-task-worker -A calliope_app -Q long_queue -l info
+celery -A calliope_app worker -n long-task-worker -Q long_queue -l info

--- a/calliope_app/compose/run-short-worker.sh
+++ b/calliope_app/compose/run-short-worker.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-celery worker -n short-task-worker -A calliope_app -Q short_queue -l info
+celery -A calliope_app worker -n short-task-worker -Q short_queue -l info

--- a/calliope_app/requirements-dev.txt
+++ b/calliope_app/requirements-dev.txt
@@ -1,6 +1,6 @@
-mock==2.0.0
-pylint==2.3.1
-pylint-django==2.0.6
+mock==4.0.3
+pylint==2.14.5
+pylint-django==2.5.3
 backtrace==0.2.1
-sphinx==3.0.3
-django-debug-toolbar==3.2.1
+sphinx==5.1.0
+django-debug-toolbar==3.5.0

--- a/calliope_app/requirements.txt
+++ b/calliope_app/requirements.txt
@@ -4,7 +4,7 @@ django==3.2.14
 django-crispy-forms==1.14.0
 django-environ>=0.4.5
 django-modeltranslation==0.18.4
-flower>=1.1.0
+# flower>=1.1.0  # contains vulnerabilities not fixed yet
 nrel-pysam==2.1.5.dev3
 pint==0.18
 psycopg2-binary==2.9.3
@@ -21,10 +21,10 @@ ipdb >= 0.11
 jinja2 >= 2.10
 natsort >= 5
 netcdf4 >= 1.2.2
-numpy==1.21.2
-pandas >= 1.2, < 1.3
-plotly >= 3.10, < 3.11
+numpy >= 1.23.1
+pandas >= 1.3
+plotly >= 5.9.0
 pyomo == 6.0
 ruamel.yaml >= 0.16
-scikit-learn >= 0.22, < 0.24
-xarray >= 0.17, < 0.18
+scikit-learn >= 1.1.1
+xarray >= 2022.6.0

--- a/calliope_app/requirements.txt
+++ b/calliope_app/requirements.txt
@@ -1,22 +1,30 @@
-calliope==0.6.7
-click==7.1.2
-django==3.2.13
-django-environ>=0.4.5
+boto3==1.24.37
+celery[redis]==5.2.7
+django==3.2.14
 django-crispy-forms==1.14.0
-psycopg2-binary==2.8.6
-boto3==1.9.145
-celery[redis]==4.3.1
-flower==0.9.2
-tornado==5.1.1
-pyyaml==5.4
-pyutilib==6.0.0
-django-modeltranslation==0.17.5
-gunicorn==19.9.0
-pyomo==6.0
-amqp==2.6.1
-vine==1.3.0
+django-environ>=0.4.5
+django-modeltranslation==0.18.4
+flower>=1.1.0
 nrel-pysam==2.1.5.dev3
-requests==2.21.0
-pympler==0.8
-scikit-learn==0.22
 pint==0.18
+psycopg2-binary==2.9.3
+pyyaml==6.0
+requests>=2.21.0
+
+pyutilib==6.0.0
+# amqp==2.6.1
+# vine==1.3.0
+
+# pip install calliope==0.6.7 --no-deps
+# install calliope depes below with Click, which conflicts with Celery
+ipdb >= 0.11
+jinja2 >= 2.10
+natsort >= 5
+netcdf4 >= 1.2.2
+numpy==1.21.2
+pandas >= 1.2, < 1.3
+plotly >= 3.10, < 3.11
+pyomo == 6.0
+ruamel.yaml >= 0.16
+scikit-learn >= 0.22, < 0.24
+xarray >= 0.17, < 0.18

--- a/calliope_app/requirements.txt
+++ b/calliope_app/requirements.txt
@@ -1,6 +1,6 @@
 boto3==1.24.37
 celery[redis]==5.2.7
-django==3.2.14
+django==3.2.15
 django-crispy-forms==1.14.0
 django-environ>=0.4.5
 django-modeltranslation==0.18.4

--- a/calliope_app/setup.py
+++ b/calliope_app/setup.py
@@ -12,13 +12,12 @@ test_requirements = []
 setup(
     author="NREL",
     author_email='engage@nrel.gov',
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Intended Audience :: Developers',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
     ],


### PR DESCRIPTION
Fix docker vulnerabilities
* Upgrade Django to version 3.2.15.
* Upgrade Celery from 4.x to 5.x
* Upgrade other related packages
* Install calliope==0.6.7 without deps, and install dependencies separately.