### PR TITLE
Upgrade Django to 3.2.16

### DIFF
--- a/calliope_app/requirements.txt
+++ b/calliope_app/requirements.txt
@@ -1,6 +1,6 @@
 boto3==1.24.37
 celery[redis]==5.2.7
-django==3.2.15
+django==3.2.16
 django-crispy-forms==1.14.0
 django-environ>=0.4.5
 django-modeltranslation==0.18.4


### PR DESCRIPTION
### What's this PR for
* Upgrade Django to 3.2.16
* Fix docker vulnerabilities