### PR TITLE
Adding space support back to validators

### DIFF
--- a/calliope_app/account/validators.py
+++ b/calliope_app/account/validators.py
@@ -5,8 +5,8 @@ from django.utils.translation import gettext_lazy as _
 
 
 unicode_chars_validator = RegexValidator(
-    slug_unicode_re,
-    _("Enter a valid string consisting of unicode letters, numbers, underscores or hyphens."),
+    r"^[\w\-]+( [\w\-]+)*$",
+    _("Enter a valid string consisting of unicode letters, numbers, underscores or hyphens. Single spaces are allowed to separate words."),
     "invalid"
 )
 

--- a/calliope_app/client/templates/base.html
+++ b/calliope_app/client/templates/base.html
@@ -88,7 +88,11 @@
 
 				{% if user.is_authenticated %}
 					<!-- Model Sharing -->
-					<a href="{% url 'settings' %}"><button class="btn btn-sm" style="height:100%;"><i class="fas fa-users"></i>&nbsp;&nbsp;{% trans "Model Sharing" %}</button></a>
+					{% if model %}
+						<a href="{% url 'settings' %}?model_uuid={{model.uuid}}"><button class="btn btn-sm" style="height:100%;"><i class="fas fa-users"></i>&nbsp;&nbsp;{% trans "Model Sharing" %}</button></a>
+					{% else %}
+						<a href="{% url 'settings' %}"><button class="btn btn-sm" style="height:100%;"><i class="fas fa-users"></i>&nbsp;&nbsp;{% trans "Model Sharing" %}</button></a>
+					{% endif %}
 				{% endif %}
 
 				<a href="https://www.nrel.gov/" target="_blank">


### PR DESCRIPTION
Adjusting registration text validator to support single spaces between words in the first name, last name, and org fields

Side improvement:
Adjusting model sharing link to default to the selected model if clicked within a model context