### PR TITLE
Enable scroll on geophires plotting page

### DIFF
--- a/calliope_app/client/templates/geophires_plotting.html
+++ b/calliope_app/client/templates/geophires_plotting.html
@@ -7,7 +7,7 @@
 <style>
     html, body {
       height: 100%;
-      overflow: hidden;
+      overflow: scroll;
     }
 </style>
 {% endblock %}


### PR DESCRIPTION
What's this PR
* Enable scroll on geophires plotting page, as there are four plots.