### PR TITLE
Fixing issue where techs could be missing

### DIFF
--- a/calliope_app/api/calliope_utils.py
+++ b/calliope_app/api/calliope_utils.py
@@ -455,11 +455,17 @@ def _yaml_outputs(model_path, outputs_dir):
                         if 'results' not in model[tl][l]['techs'][t]:
                             model[tl][l]['techs'][t]['results'] = {}
                         if tl == 'links':
-                            model[tl][l]['techs'][t]['results'][v+'_equals'] = float(r_df.loc[(r_df['locs'] == l1) &
+                            if r_df.loc[(r_df['locs'] == l1) & (r_df['techs'] == t+':'+l2)].empty:
+                                model[tl][l]['techs'][t]['results'][v+'_equals'] = 0
+                            else:
+                                model[tl][l]['techs'][t]['results'][v+'_equals'] = float(r_df.loc[(r_df['locs'] == l1) &
                                                                                 (r_df['techs'] == t+':'+l2)][v].values[0])
                         else:
-                            model[tl][l]['techs'][t]['results'][v+'_equals'] = float(r_df.loc[(r_df['locs'] == l) &
-                                                                                (r_df['techs'] == t)][v].values[0])
+                            if r_df.loc[(r_df['locs'] == l) & (r_df['techs'] == t)].empty:
+                                model[tl][l]['techs'][t]['results'][v+'_equals'] = 0
+                            else:
+                                model[tl][l]['techs'][t]['results'][v+'_equals'] = float(r_df.loc[(r_df['locs'] == l) &
+                                                                                    (r_df['techs'] == t)][v].values[0])
     if has_outputs:
         yaml.dump(model, open(os.path.join(outputs_dir,'model_results.yaml'),'w+'), default_flow_style=False)
 


### PR DESCRIPTION
Found an issue where if no storage constraints are set on supply+ it doesn't show up in results_storage_cap if nothing is built. Adding code to default a 0 capacity in results_yaml if the loc_tech is missing from the energy/storage capacity file to prevent model errors if this happens