### PR TITLE
Adding Xpress python bindings

### DIFF
--- a/calliope_app/api/fixtures/admin_run_parameter.json
+++ b/calliope_app/api/fixtures/admin_run_parameter.json
@@ -364,7 +364,7 @@
       "can_evolve": "False",
       "name": "solver",
       "default_value": "amplxpress",
-      "choices": "[\"glpk\",\"amplxpress\"]"
+      "choices": "[\"glpk\",\"amplxpress\",\"xpress_direct\"]"
     }
   },
   {

--- a/calliope_app/requirements.txt
+++ b/calliope_app/requirements.txt
@@ -28,3 +28,4 @@ pyomo == 6.2
 ruamel.yaml >= 0.16
 scikit-learn >= 1.1.1
 xarray >= 2022.6.0
+xpress >= 8.12.3


### PR DESCRIPTION
Adding Xpress Python wrapper package and adding option to specify "xpress_direct" to have Pyomo use the direct wrapper instead of ampl