### PR TITLE
Fix carriers plotting issue for old runs

### DIFF
--- a/calliope_app/api/models/outputs.py
+++ b/calliope_app/api/models/outputs.py
@@ -161,8 +161,10 @@ class Run(models.Model):
         carriers = [(key, len(values)) for key, values in carriers.items()]
         carriers = sorted(carriers, key=lambda k: k[1], reverse=True)
         carriers_d = self.read_input('carriers.yaml')
+        if not carriers_d:
+            carriers_d = {}
         for k in carriers:
-            if not carriers_d or k[0] not in carriers_d.keys():
+            if k[0] not in carriers_d.keys():
                 carriers_d[k[0]] = {'rate':'kW','quantity':'kWh'}
         meta['carriers'] = [(k[0],carriers_d[k[0]]['rate'],carriers_d[k[0]]['quantity']) for k in carriers]
         return meta


### PR DESCRIPTION
Fixing bug with trying to load carrier units for plots in runs that predate carrier units