### PR TITLE
Fix model copying bug with carriers

### DIFF
--- a/calliope_app/api/models/configuration.py
+++ b/calliope_app/api/models/configuration.py
@@ -173,6 +173,10 @@ class Model(models.Model):
         params = Tech_Param.objects.filter(technology__in=self.technologies,
                                            parameter__name='color')
         return {c.technology_id: c.value for c in params}
+    
+    @property
+    def carriers_set(self):
+        return self.carriers.all()
 
     def check_model_carrier_units(self,carrier):
         units_in_ids= [4,5,70]

--- a/calliope_app/api/models/configuration.py
+++ b/calliope_app/api/models/configuration.py
@@ -175,8 +175,8 @@ class Model(models.Model):
         return {c.technology_id: c.value for c in params}
     
     @property
-    def carriers_set(self):
-        return self.carriers.all()
+    def carriers(self):
+        return self.carrier_set.all()
 
     def check_model_carrier_units(self,carrier):
         units_in_ids= [4,5,70]
@@ -1573,7 +1573,7 @@ class Carrier(models.Model):
 
     name = models.CharField(max_length=200)
     description = models.TextField(blank=True, null=True)
-    model = models.ForeignKey(Model, related_name='carriers', on_delete=models.CASCADE)
+    model = models.ForeignKey(Model, on_delete=models.CASCADE)
     rate_unit = models.CharField(max_length=20)
     quantity_unit = models.CharField(max_length=20)
     created = models.DateTimeField(auto_now_add=True, null=True)

--- a/calliope_app/client/templates/technology_parameters.html
+++ b/calliope_app/client/templates/technology_parameters.html
@@ -84,14 +84,14 @@
 						<select {% if not can_edit %}disabled{% endif %} class="static_inputs form-control parameter-value parameter-value-existing" name="edit[parameter][{{ param.parameter_id }}]" data-value="{{ param.value }}">
 							{% if param.choices %}
 								{% for choice in param.choices %}
-								<option value="{{ choice }}" {% if choice == param.value %}selected{% endif %}>{{ choice }}</option>
+								<option value="{{ choice.name }}" {% if choice.name == param.value %}selected{% endif %}>{{ choice.name }}</option>
 								{% endfor %}
 							{% else %}
 								{% if not param.value %}
 								<option selected></option>
 								{% endif %}
 								{% for choice in carriers %}
-								<option value="{{ choice }}" {% if choice == param.value %}selected{% endif %}>{{ choice }}</option>
+								<option value="{{ choice.name }}" {% if choice.name == param.value %}selected{% endif %}>{{ choice.name }}</option>
 								{% endfor %}
 							{% endif %}
 						</select>


### PR DESCRIPTION
Fixing bug where putting a related_name on carriers broke the model copying code that assumed the default _set to copy model sub-objects