### PR TITLE
Pin ruamel yaml == 0.16.0

### DIFF
--- a/calliope_app/requirements.txt
+++ b/calliope_app/requirements.txt
@@ -25,7 +25,7 @@ numpy >= 1.23.1
 pandas >= 1.3, <1.4
 plotly >= 5.9.0
 pyomo == 6.2
-ruamel.yaml >= 0.16
+ruamel.yaml == 0.16.0
 scikit-learn >= 1.1.1
 xarray >= 2022.6.0
 xpress >= 8.12.3


### PR DESCRIPTION
```bash
calliope-short-worker  | "safe_load()" has been removed, use
calliope-short-worker  |
calliope-short-worker  |   yaml = YAML(typ='safe', pure=True)
calliope-short-worker  |   yaml.load(...)
calliope-short-worker  |
calliope-short-worker  | instead of file "/usr/local/lib/python3.8/site-packages/calliope/core/attrdict.py", line 47
calliope-short-worker  |
calliope-short-worker  |         result = ruamel_yaml.safe_load(src)
```

Pin `ruamel.yaml == 0.16.0` as a temp solution.