### PR TITLE
Update compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,4 +99,3 @@ services:
       - long_worker
       - celery_flower
     command: ["./wait-for-postgres.sh", "compose/run-calliope-app.sh"]
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,3 +99,4 @@ services:
       - long_worker
       - celery_flower
     command: ["./wait-for-postgres.sh", "compose/run-calliope-app.sh"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - ./postgres/data:/var/lib/postgresql/data
 
   short_worker:
+    platform: linux/x86_64
     build:
       context: calliope_app
       dockerfile: compose/Dockerfile
@@ -39,6 +40,7 @@ services:
     command: ["compose/run-short-worker.sh"]
 
   long_worker:
+    platform: linux/x86_64
     build:
       context: calliope_app
       dockerfile: compose/Dockerfile
@@ -55,6 +57,7 @@ services:
     command: ["compose/run-long-worker.sh"]
 
   celery_flower:
+    platform: linux/x86_64
     build:
       context: calliope_app
       dockerfile: compose/Dockerfile
@@ -75,7 +78,8 @@ services:
     command: ["compose/run-celery-flower.sh"]
 
   app:
-    build: 
+    platform: linux/x86_64
+    build:
       context: calliope_app
       dockerfile: compose/Dockerfile
     image: calliope-app


### PR DESCRIPTION
The changed code in this pull request ensures that the Docker Compose files run on the Linux/x86_64 architecture. This update is important so that M1 and M2 chip users can run Docker Compose. 