### PR TITLE
Fixing map-legend

### DIFF
--- a/calliope_app/client/static/js/main.js
+++ b/calliope_app/client/static/js/main.js
@@ -706,9 +706,12 @@ function add_marker(name, id, type, draggable, coordinates) {
 	marker._element.addEventListener('mouseenter', function(e) {
 		var m = e.target._marker;
 		$('#map-legend').html(m.description);
+		$('#map-legend').css('display', '');
+
 	});
 	marker._element.addEventListener('mouseleave', function(e) {
 		$('#map-legend').html("");
+		$('#map-legend').css('display', 'none');
 	});
 	marker._element.addEventListener('mouseup', function(e) {
 		var m = e.target._marker;

--- a/calliope_app/client/templates/map_container_resizable.html
+++ b/calliope_app/client/templates/map_container_resizable.html
@@ -1,4 +1,4 @@
-<div id="map_container" style="position: relative; width: 100%; height: 500px; border: 1px solid black;">
+<div id="map_container" style="position: relative; width: 100%; height: 100%; border: 1px solid black;">
     <div id="map" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 1; border: solid;">
     </div>
     <div id="map-legend-container" style="position: absolute; margin-top: 5px; margin-left: 5px; z-index: 1000001;">

--- a/calliope_app/client/templates/map_container_resizable.html
+++ b/calliope_app/client/templates/map_container_resizable.html
@@ -1,5 +1,11 @@
-<div id="map_container" style="width: 100%; height: 100%; z-index: 2;">
-    <div class="col-12" id="map" style="height: 100%; border:solid;"></div>
-    <div class="col-12" id="map-legend-container"><div id="map-legend"></div></div>
-    {% include "spinner.html" %}
+<div id="map_container" style="position: relative; width: 100%; height: 500px; border: 1px solid black;">
+    <div id="map" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 1; border: solid;">
+    </div>
+    <div id="map-legend-container" style="position: absolute; margin-top: 5px; margin-left: 5px; z-index: 1000001;">
+        <div id="map-legend" style="display: none;">
+    </div>
+    </div>
+    <div id="spinner" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); z-index: 2;">
+        {% include "spinner.html" %}
+    </div>
 </div>


### PR DESCRIPTION
This is a PR to fix the map legend that was previously interrupted by splitting the scenario tab. The legend for the scenarios tab is currently missing in dev. This PR fixes that, such that when you hover over a node, the map-legend appears in the top left corner as it does in the master branch. 