### PR TITLE
engage90-Remove informational version of docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,3 @@
-version: "3"
-
-volumes:
-  data:
-
 services:
 
   redis:
@@ -79,7 +74,7 @@ services:
 
   app:
     platform: linux/x86_64
-    build: 
+    build:
       context: calliope_app
       dockerfile: compose/Dockerfile
     image: calliope-app
@@ -99,3 +94,7 @@ services:
       - long_worker
       - celery_flower
     command: ["./wait-for-postgres.sh", "compose/run-calliope-app.sh"]
+
+
+volumes:
+  data:


### PR DESCRIPTION
After having docker engine updated,

Now it's showing WARN when starting docker-compose at local,

It shows:

WARN[0000] ~/engage/engage-public/docker-compose.yml: `version` is obsolete

Solution:
Remove the top version,
more information, please refer here - https://github.com/jasonacox/Powerwall-Dashboard/issues/453#issuecomment-2008619928 