### PR TITLE
Geophires Axis Labelling

### DIFF
--- a/calliope_app/client/static/js/geophires_plotting.js
+++ b/calliope_app/client/static/js/geophires_plotting.js
@@ -43,7 +43,7 @@ $.getJSON('/geophires/outputs/', params, function(data) {
       'title': 'Avg. Electric capacity (MWe)'
     },
     'yaxis': {
-      'title': 'Subsurface Total Cost ($M)'
+      'title': 'Surface Total Cost ($M)'
     }
   }
   if (!template_type.includes("Direct") || !template_type.includes("Flash")) {


### PR DESCRIPTION
Fixes Geophires axis labeling in graph. This PR changes the y-axis from ```Suburface Total Cost ($M)``` to ```Surface Total Cost ($M)```.

![image](https://github.com/NREL/engage/assets/157855136/09b34f18-5225-4b6c-a6b9-bb1f55ca4ac8)
