### PR TITLE
Scenario description

### DIFF
--- a/calliope_app/client/templates/scenario_details.html
+++ b/calliope_app/client/templates/scenario_details.html
@@ -20,7 +20,7 @@
 
             <label for="scenario-description" class="col-sm-3 col-form-label"><b>{% trans "Description" %}:</b></label>
             <div class="col-sm-9">
-              <textarea id="scenario_description" class="scenario_description" data-placement="right" rows="4"> {{session_scenario.description}} </textarea>
+              <textarea id="scenario_description" class="scenario_description" data-placement="right" rows="4"> {% if session_scenario.description is not none %}{{ session_scenario.description}}{% else %}{% endif %}</textarea>
              </div>
          </div>
     </div>

--- a/calliope_app/client/templates/scenario_details.html
+++ b/calliope_app/client/templates/scenario_details.html
@@ -20,7 +20,7 @@
 
             <label for="scenario-description" class="col-sm-3 col-form-label"><b>{% trans "Description" %}:</b></label>
             <div class="col-sm-9">
-              <textarea id="scenario_description" class="scenario_description" data-placement="right" rows="4"> {% if session_scenario.description is not none %}{{ session_scenario.description}}{% else %}{% endif %}</textarea>
+              <textarea id="scenario_description" class="scenario_description" data-placement="right" rows="4"> {% if session_scenario.description != None %}{{ session_scenario.description}}{% else %}{% endif %}</textarea>
              </div>
          </div>
     </div>
@@ -30,10 +30,8 @@
 <script>
 
   $( document ).ready(function() {
-
     $('#scenario_description, #scenario_name').on('change keyup paste', function () {
       $('#master-save').removeClass('hide');
     });
-
   });
 </script>


### PR DESCRIPTION
This makes sure that the scenario description defaults to an empty string rather than none.
![image](https://github.com/NREL/engage/assets/157855136/853c7fcc-e2f9-4117-8633-6c36fd99eed7)
vs. 
![image](https://github.com/NREL/engage/assets/157855136/db4ee3d9-bcaf-4fcf-8f65-c74bad788299)
