### PR TITLE
Dockerfile clean up & remove git

### DIFF
--- a/calliope_app/compose/Dockerfile
+++ b/calliope_app/compose/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim-bullseye as app
+FROM python:3.8-slim-bookworm as app
 
 # set environment variables
 ENV LC_ALL=C.UTF-8
@@ -23,20 +23,19 @@ RUN apt-get update -y --fix-missing \
     liblapack-dev \
     libmetis-dev \
     coinor-cbc \
+    git \
     && rm -rf /var/lib/apt/lists/*
 
 # install python packages
 WORKDIR /www
 COPY requirements.txt requirements-dev.txt /www/
-RUN apt-get update && apt-get install -y git
 RUN pip install --upgrade pip
-RUN pip install https://github.com/NREL/GEOPHIRES-X/archive/main.zip
-RUN pip install -r requirements.txt
-RUN pip install -r requirements-dev.txt
-RUN pip list
+RUN pip install -r requirements.txt && pip install -r requirements-dev.txt
 # Install calliope without dependencies, as already installed in requirements
-RUN pip install calliope==0.6.8 --no-deps
-RUN pip install flower>=1.1.0
+RUN pip install calliope==0.6.8 --no-deps && pip install flower>=1.1.0
+
+# Uninstall git
+RUN apt remove git -y && apt autoremove -y
 
 
 COPY . .


### PR DESCRIPTION
Git is used to install GEOPHIRES-X, no need anymore after the package installation, remove to make image smaller.