### PR TITLE
Engage 95 group constraints fixture updates

### DIFF
--- a/calliope_app/api/fixtures/admin_group_constraint.json
+++ b/calliope_app/api/fixtures/admin_group_constraint.json
@@ -107,12 +107,21 @@
           "name": "demand_share_min",
           "pretty_name": "Demand Share Min",
           "description": "Minimum share of carrier demand met from a set of technologies across a set of locations, on average over the entire model period.",
+          "where": "",
           "equations": [
-              {
-                "expression": "sum(flow_out_non_transmission_techs[||locs_lhs||||techs_rhs||||techs_lhs||||techs_rhs||||carriers_lhs||||carriers_rhs||], over=[nodes, techs, timesteps, carriers]) <= $value_1"
-              }
+            {
+              "expression": ""
+            }
           ],
           "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
             "techs_lhs": {
               "yaml": [
                 {
@@ -128,6 +137,14 @@
                 }
               ],
               "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
             },
             "locs_lhs": {
               "yaml": [
@@ -171,7 +188,3565 @@
               ],
               "show": true
             }
+          }
+        }
+      },
+      {
+        "pk": 3,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "demand_share_max",
+          "pretty_name": "Demand Share Max",
+          "description": "Maximum share of carrier demand met from a set of technologies across a set of locations, on average over the entire model period.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "carriers_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            },
+            "carriers_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 4,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "demand_share_equals",
+          "pretty_name": "Demand Share Equals",
+          "description": "Share of carrier demand met from a set of technologies across a set of locations, on average over the entire model period.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "carriers_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            },
+            "carriers_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 5,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "demand_share_per_timestep_min",
+          "pretty_name": "Demand Share Per Timestep Min",
+          "description": "Minimum share of carrier demand met from a set of technologies across a set of locations, in each individual timestep.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "carriers_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            },
+            "carriers_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 6,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "demand_share_per_timestep_max",
+          "pretty_name": "Demand Share Per Timestep Max",
+          "description": "Maximum share of carrier demand met from a set of technologies across a set of locations, in each individual timestep.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "carriers_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            },
+            "carriers_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 7,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "demand_share_per_timestep_equals",
+          "pretty_name": "Demand Share Per Timestep Equals",
+          "description": "Share of carrier demand met from a set of technologies across a set of locations, in each individual timestep.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "carriers_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            },
+            "carriers_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 8,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "demand_share_per_timestep_decision",
+          "pretty_name": "Demand Share Per Timestep Decision",
+          "description": "Turns the per-timestep share of carrier demand met from a set of technologies across a set of locations into a model decision variable.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "carriers_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            },
+            "carriers_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 9,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "flow_prod_share_min",
+          "pretty_name": "Flow Prod Share Min",
+          "description": "Minimum share of carrier production met from a set of technologies across a set of locations, on average over the entire model period.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "carriers_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            },
+            "carriers_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 10,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "flow_prod_share_max",
+          "pretty_name": "Flow Prod Share Max",
+          "description": "Maximum share of carrier production met from a set of technologies across a set of locations, on average over the entire model period.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "carriers_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            },
+            "carriers_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 11,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "flow_prod_share_equals",
+          "pretty_name": "Flow Prod Share Equals",
+          "description": "Share of carrier production met from a set of technologies across a set of locations, on average over the entire model period.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "carriers_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            },
+            "carriers_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 12,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "flow_prod_share_per_timestep_min",
+          "pretty_name": "Flow Prod Share Per Timestep Min",
+          "description": "Minimum share of carrier production met from a set of technologies across a set of locations, in each individual timestep.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "carriers_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            },
+            "carriers_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 13,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "flow_prod_share_per_timestep_max",
+          "pretty_name": "Flow Prod Share Per Timestep Max",
+          "description": "Maximum share of carrier production met from a set of technologies across a set of locations, in each individual timestep.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "carriers_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            },
+            "carriers_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 14,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "flow_prod_share_per_timestep_equals",
+          "pretty_name": "Flow Prod Share Per Timestep Equals",
+          "description": "Share of carrier production met from a set of technologies across a set of locations, in each individual timestep.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "carriers_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            },
+            "carriers_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 15,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "net_import_share_min",
+          "pretty_name": "Net Import Share Min",
+          "description": "Minimum share of demand met from transmission technologies into a set of locations, on average over the entire model period. All transmission technologies of the chosen carrier are added automatically and technologies must thus not be defined explicitly.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "carriers_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            },
+            "carriers_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 16,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "net_import_share_max",
+          "pretty_name": "Net Import Share Max",
+          "description": "Maximum share of demand met from transmission technologies into a set of locations, on average over the entire model period. All transmission technologies of the chosen carrier are added automatically and technologies must thus not be defined explicitly.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "carriers_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            },
+            "carriers_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 17,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "net_import_share_equals",
+          "pretty_name": "Net Import Share Equals",
+          "description": "Share of demand met from transmission technologies into a set of locations, on average over the entire model. All transmission technologies of the chosen carrier are added automatically and technologies must thus not be defined explicitly. period.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "carriers_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            },
+            "carriers_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 18,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "flow_prod_min",
+          "pretty_name": "Flow Prod Min",
+          "description": "Minimum absolute sum of supplied energy (flow_prod) over all timesteps for a set of technologies across a set of locations.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "carriers_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            },
+            "carriers_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 19,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "flow_prod_max",
+          "pretty_name": "Flow Prod Max",
+          "description": "Maximum absolute sum of supplied energy (flow_prod) over all timesteps for a set of technologies across a set of locations.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "carriers_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            },
+            "carriers_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 20,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "flow_prod_equals",
+          "pretty_name": "Flow Prod Equals",
+          "description": "Exact absolute sum of supplied energy (flow_prod) over all timesteps for a set of technologies across a set of locations.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "carriers_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            },
+            "carriers_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 21,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "flow_con_min",
+          "pretty_name": "Flow Con Min",
+          "description": "Minimum sum of consumed energy (flow_con) over all timesteps for a set of conversion/demand technologies across a set of locations. Values are negative and are relative to zero, i.e. a minimum value of -1 means that consumed energy must be < -1",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "carriers_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            },
+            "carriers_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 22,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "flow_con_max",
+          "pretty_name": "Flow Con Max",
+          "description": "Maximum sum of consumed energy (flow_con) over all timesteps for a set of conversion/demand technologies across a set of locations. Values are negative and are relative to zero, i.e. a maximum value of -1 means that consumed energy must be > -1",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "carriers_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            },
+            "carriers_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 23,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "flow_con_equals",
+          "pretty_name": "Flow Con Equals",
+          "description": "Exact sum of consumed energy (flow_con) over all timesteps for a set of conversion/demand technologies across a set of locations. Values are negative.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "carriers_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            },
+            "carriers_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "carriers"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 24,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "cost_max",
+          "pretty_name": "Cost Max",
+          "description": "Maximum total cost from a set of technologies across a set of locations.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "costs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "costs"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 25,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "cost_min",
+          "pretty_name": "Cost Min",
+          "description": "Minimum total cost from a set of technologies across a set of locations.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "costs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "costs"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 26,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "cost_equals",
+          "pretty_name": "Cost Equals",
+          "description": "Total cost from a set of technologies across a set of locations must equal given value.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "costs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "costs"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 27,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "cost_var_max",
+          "pretty_name": "Cost Var Max",
+          "description": "Maximum variable cost from a set of technologies across a set of locations.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "costs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "costs"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 28,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "cost_var_min",
+          "pretty_name": "Cost Var Min",
+          "description": "Minimum variable cost from a set of technologies across a set of locations.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "costs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "costs"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 29,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "cost_var_equals",
+          "pretty_name": "Cost Var Equals",
+          "description": "Variable cost from a set of technologies across a set of locations must equal given value.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "costs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "costs"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 30,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "cost_investment_max",
+          "pretty_name": "Cost Investment Max",
+          "description": "Maximum investment cost from a set of technologies across a set of locations.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "costs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "costs"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 31,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "cost_investment_min",
+          "pretty_name": "Cost Investment Min",
+          "description": "Minimum investment cost from a set of technologies across a set of locations.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "costs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "costs"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 32,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "cost_investment_equals",
+          "pretty_name": "Cost Investment Equals",
+          "description": "Investment cost from a set of technologies across a set of locations must equal given value.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "costs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "costs"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 33,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "energy_cap_share_min",
+          "pretty_name": "Energy Cap Share Min",
+          "description": "Minimum share of installed capacity from a set of technologies across a set of locations.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 34,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "energy_cap_share_max",
+          "pretty_name": "Energy Cap Share Max",
+          "description": "Maximum share of installed capacity from a set of technologies across a set of locations.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 35,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "energy_cap_share_equals",
+          "pretty_name": "Energy Cap Share Equals",
+          "description": "Exact share of installed capacity from a set of technologies across a set of locations.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 36,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "energy_cap_min",
+          "pretty_name": "Energy Cap Min",
+          "description": "Minimum installed capacity from a set of technologies across a set of locations.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 37,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "energy_cap_max",
+          "pretty_name": "Energy Cap Max",
+          "description": "Maximum installed capacity from a set of technologies across a set of locations.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 38,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "energy_cap_equals",
+          "pretty_name": "Energy Cap Equals",
+          "description": "Exact installed capacity from a set of technologies across a set of locations.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 39,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "resource_area_min",
+          "pretty_name": "Resource Area Min",
+          "description": "Minimum resource area used by a set of technologies across a set of locations.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 40,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "resource_area_max",
+          "pretty_name": "Resource Area Max",
+          "description": "Maximum resource area used by a set of technologies across a set of locations.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 41,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "resource_area_equals",
+          "pretty_name": "Resource Area Equals",
+          "description": "Exact resource area used by a set of technologies across a set of locations.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 42,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "storage_cap_min",
+          "pretty_name": "Storage Cap Min",
+          "description": "Minimum installed storage capacity from a set of technologies across a set of locations.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 43,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "storage_cap_max",
+          "pretty_name": "Storage Cap Max",
+          "description": "Maximum installed storage capacity from a set of technologies across a set of locations.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
+        }
+      },
+      {
+        "pk": 44,
+        "model": "api.group_constraint",
+        "fields": {
+          "name": "storage_cap_equals",
+          "pretty_name": "Storage Cap Equals",
+          "description": "Exact installed storage capacity from a set of technologies across a set of locations.",
+          "where": "",
+          "equations": [
+            {
+              "expression": ""
+            }
+          ],
+          "slices": {
+            "techs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "techs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "techs"
+            },
+            "locs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_lhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            },
+            "locs_rhs": {
+              "yaml": [
+                {
+                  "expression": "[VALUE]"
+                }
+              ],
+              "dim": "locs"
+            }
+          },
+          "sub_expression": {
+            "value_1": {
+              "yaml": [
+                {
+                  "expression": "VALUE"
+                }
+              ],
+              "show": true
+            }
+          }
         }
       }
-    }
 ]

--- a/calliope_app/client/static/js/scenarios.js
+++ b/calliope_app/client/static/js/scenarios.js
@@ -281,17 +281,17 @@ function convertToJSON() {
 
             Object.entries(adminGroupConstraint.sub_expression).forEach(([key, value]) => {
                 if (adminGroupConstraint.sub_expression[key].show) {
-                    let tempSubExpression = tempDialogObj[constraint]?.sub_expression[key][0]?.expression;
+                    let tempSubExpression = tempDialogObj[constraint]?.sub_expressions[key][0]?.expression;
                     if (tempSubExpression == [] || tempSubExpression == "") {
-                        delete tempDialogObj[constraint].sub_expression[key];
+                        delete tempDialogObj[constraint].sub_expressions[key];
                     } else {
-                        tempDialogObj[constraint].sub_expression[key][0].expression = Number(tempSubExpression) ? Number(tempSubExpression) : 0;
+                        tempDialogObj[constraint].sub_expressions[key][0].expression = Number(tempSubExpression) ? Number(tempSubExpression) : 0;
                     }
                 } else {
-                    tempDialogObj[constraint].sub_expression[key] = structuredClone(adminGroupConstraint.sub_expression[key].yaml);
+                    tempDialogObj[constraint].sub_expressions[key] = structuredClone(adminGroupConstraint.sub_expression[key].yaml);
                 } 
-                if (tempDialogObj[constraint].sub_expression[key]) {
-                    let tempSubExpression = tempDialogObj[constraint]?.sub_expression[key][0]?.expression;
+                if (tempDialogObj[constraint].sub_expressions[key]) {
+                    let tempSubExpression = tempDialogObj[constraint]?.sub_expressions[key][0]?.expression;
 
                     const sliceKeys = tempSubExpression.split("[")[1].split("]")[0].split("||").filter(key => key !== "");
 
@@ -303,7 +303,7 @@ function convertToJSON() {
                     });
 
                     tempSubExpression = tempSubExpression.replaceAll("||||", ",").replaceAll("||", "").replace("[]", "");
-                    tempDialogObj[constraint].sub_expression[key][0].expression = tempSubExpression;
+                    tempDialogObj[constraint].sub_expressions[key][0].expression = tempSubExpression;
                 }
             });
 
@@ -432,7 +432,7 @@ function renderSubExpressions(constraint, constraintId, constraintContent, admin
                     name='${constraint}' 
                     data-key=${key} 
                     class='form-control smol' 
-                    value='${dialogObj[constraint].sub_expression[key][0]?.expression || ""}' 
+                    value='${dialogObj[constraint].sub_expressions[key][0]?.expression || ""}' 
                     step='1'
                 >
                 </input>
@@ -441,7 +441,7 @@ function renderSubExpressions(constraint, constraintId, constraintContent, admin
             $(constraintContent).append(input);
 
             $(`#${constraintId}${key}-val`).on('input', function() {
-                dialogObj[$(this).attr('name')].sub_expression[$(this).attr('data-key')][0].expression = $(this).val();
+                dialogObj[$(this).attr('name')].sub_expressions[$(this).attr('data-key')][0].expression = $(this).val();
             });
         }
     });
@@ -898,12 +898,12 @@ function activate_scenario_settings() {
 
                         Object.entries(adminGroupConstraint.sub_expression).forEach(([key, value]) => {
                             if (value.show) {
-                                if (!tempDialogObj[constraint].sub_expression[key]) {
-                                    tempDialogObj[constraint].sub_expression[key] = structuredClone(value.yaml);
-                                    tempDialogObj[constraint].sub_expression[key][0].expression = value.yaml[0].expression == "[VALUE]" ? [] : "";
+                                if (!tempDialogObj[constraint].sub_expressions[key]) {
+                                    tempDialogObj[constraint].sub_expressions[key] = structuredClone(value.yaml);
+                                    tempDialogObj[constraint].sub_expressions[key][0].expression = value.yaml[0].expression == "[VALUE]" ? [] : "";
                                 } else {
-                                    let tempSubExpression = tempDialogObj[constraint].sub_expression[key][0].expression;
-                                    tempDialogObj[constraint].sub_expression[key][0].expression = Number(tempSubExpression);
+                                    let tempSubExpression = tempDialogObj[constraint].sub_expressions[key][0].expression;
+                                    tempDialogObj[constraint].sub_expressions[key][0].expression = Number(tempSubExpression);
                                 }
                             }
                         });
@@ -1071,11 +1071,11 @@ function activate_scenario_settings() {
                     dialogObj[newGroupConstraint].slices[key] = structuredClone(value.yaml);
                     dialogObj[newGroupConstraint].slices[key][0].expression = [];
                 });
-                dialogObj[newGroupConstraint].sub_expression = dialogObj[newGroupConstraint].sub_expression ? dialogObj[newGroupConstraint].sub_expression : {};
+                dialogObj[newGroupConstraint].sub_expressions = dialogObj[newGroupConstraint].sub_expressions ? dialogObj[newGroupConstraint].sub_expressions : {};
                 Object.entries(adminGroupConstraint.sub_expression).forEach(([key, value]) => {
                     if (value.show) {
-                        dialogObj[newGroupConstraint].sub_expression[key] = structuredClone(value.yaml);
-                        dialogObj[newGroupConstraint].sub_expression[key][0].expression = "";
+                        dialogObj[newGroupConstraint].sub_expressions[key] = structuredClone(value.yaml);
+                        dialogObj[newGroupConstraint].sub_expressions[key][0].expression = "";
                     }
                 });
                 if (adminGroupConstraint.for_each) {

--- a/calliope_app/scripts/fixtures/generate_group_contraints_fixture.py
+++ b/calliope_app/scripts/fixtures/generate_group_contraints_fixture.py
@@ -1,0 +1,134 @@
+import json
+import pandas as pd
+
+def generate_constraints_json(df):
+    json_list = []
+    pk = 1
+
+    for index, row in df.iterrows():
+        name = row['Name']
+        value = row['Dimensions']
+        description = row['Description']
+
+        # Convert the name to pretty_name
+        pretty_name = name.replace('_', ' ').title()
+
+        json_obj = {
+            "pk": pk,
+            "model": "api.group_constraint",
+            "fields": {
+                "name": name,
+                "pretty_name": pretty_name,
+                "description": description,
+                "where": "",
+                "equations": [
+                    {
+                        "expression": ""
+                    }
+                ],
+                "slices": {
+                    "techs": {
+                        "yaml": [
+                            {
+                                "expression": "[VALUE]"
+                            }
+                        ],
+                        "dim": "techs"
+                    },
+                    "techs_lhs": {
+                        "yaml": [
+                            {
+                                "expression": "[VALUE]"
+                            }
+                        ],
+                        "dim": "techs"
+                    },
+                    "techs_rhs": {
+                        "yaml": [
+                            {
+                                "expression": "[VALUE]"
+                            }
+                        ],
+                        "dim": "techs"
+                    },
+                    "locs": {
+                        "yaml": [
+                            {
+                                "expression": "[VALUE]"
+                            }
+                        ],
+                        "dim": "locs"
+                    },
+                    "locs_lhs": {
+                        "yaml": [
+                            {
+                                "expression": "[VALUE]"
+                            }
+                        ],
+                        "dim": "locs"
+                    },
+                    "locs_rhs": {
+                        "yaml": [
+                            {
+                                "expression": "[VALUE]"
+                            }
+                        ],
+                        "dim": "locs"
+                    }
+                },
+                "sub_expression": {
+                    "value_1": {
+                        "yaml": [
+                            {
+                                "expression": "VALUE"
+                            }
+                        ],
+                        "show": True
+                    }
+                }
+            }
+        }
+
+        if value == "carriers":
+            json_obj["fields"]["slices"]["carriers_lhs"] = {
+                "yaml": [
+                    {
+                        "expression": "[VALUE]"
+                    }
+                ],
+                "dim": "carriers"
+            }
+            json_obj["fields"]["slices"]["carriers_rhs"] = {
+                "yaml": [
+                    {
+                        "expression": "[VALUE]"
+                    }
+                ],
+                "dim": "carriers"
+            }
+
+        if value == "costs":
+            json_obj["fields"]["slices"]["costs"] = {
+                "yaml": [
+                    {
+                        "expression": "[VALUE]"
+                    }
+                ],
+                "dim": "costs"
+            }
+
+        json_list.append(json_obj)
+        pk += 1
+
+    return json_list
+
+input_file = "group_constraints_fixture.xlsx"
+df = pd.read_excel(input_file)
+
+json_output = generate_constraints_json(df)
+
+output_file = "constraints_output.json"
+with open(output_file, "w") as f:
+    json.dump(json_output, f, indent=2)
+
+print(f"JSON data written to {output_file}")


### PR DESCRIPTION
docker-compose exec app python manage.py loaddata --app api admin_group_constraint.json

- left in pk = 1 for a working equations example for now
- Renamed carrier to flow
- Let me know if I missed any other renames or if new constraint types are needed. 
- Group constraint script xcel sheet [C7_Admin_Group_Constraints.xlsx](https://nrel.sharepoint.com/:x:/r/sites/engage/Shared%20Documents/Application%20Development/C7/C7_Admin_Group_Constraints.xlsx?d=w64faba6c869040f5895015ade6842f62&csf=1&web=1&e=aJbFLy)

TODO: 
- Also need to fill out where and for_each for some of these.