### PR TITLE
Explicitly adding older version of coolprop

### DIFF
--- a/calliope_app/requirements.txt
+++ b/calliope_app/requirements.txt
@@ -1,4 +1,5 @@
 django_ratelimit==4.1.0
+coolprop<=6.7.0
 git+https://github.com/NREL/GEOPHIRES-X.git#egg=geophires-x
 boto3==1.24.37
 celery[redis]==5.3.0


### PR DESCRIPTION
Coolprop 6.8.0 seems to break when installing from pip. Reverting to 6.7.0 explicitly to resolve