### PR TITLE
Install geophires-x tag 3.8.10

### DIFF
--- a/calliope_app/compose/Dockerfile
+++ b/calliope_app/compose/Dockerfile
@@ -29,8 +29,8 @@ RUN apt-get update -y --fix-missing \
 # install python packages
 WORKDIR /www
 COPY requirements.txt requirements-dev.txt /www/
-RUN pip install --upgrade pip
-RUN pip install -r requirements.txt && pip install -r requirements-dev.txt
+RUN pip install --upgrade pip && pip install -r requirements.txt && pip install -r requirements-dev.txt
+RUN pip install "git+https://github.com/NREL/GEOPHIRES-X.git@v3.8.10"
 # Install calliope without dependencies, as already installed in requirements
 RUN pip install calliope==0.6.8 --no-deps
 

--- a/calliope_app/requirements.txt
+++ b/calliope_app/requirements.txt
@@ -1,6 +1,5 @@
 django_ratelimit==4.1.0
 coolprop<=6.7.0
-git+https://github.com/NREL/GEOPHIRES-X.git@v3.9.8#egg=geophires-x
 boto3==1.24.37
 celery[redis]==5.3.0
 django==4.2.23
@@ -8,7 +7,7 @@ django-crispy-forms==1.14.0
 django-environ>=0.4.5
 django-modeltranslation==0.18.12
 flower>=2.0.1
-nrel-pysam==2.2.0
+nrel-pysam==3.0.2
 pint==0.21
 psycopg2-binary==2.9.3
 pyyaml==6.0


### PR DESCRIPTION
### What's Changed

This installation `pip install "git+https://github.com/NREL/GEOPHIRES-X.git` caused issue, as GEOPHIRES-X introduced broken changes. 

So install from a history tag `pip install "git+https://github.com/NREL/GEOPHIRES-X.git@v.3.8.10`.