### PR TITLE
Fixing duplicate indexed params on loc_techs

### DIFF
--- a/calliope_app/api/calliope_utils.py
+++ b/calliope_app/api/calliope_utils.py
@@ -215,7 +215,6 @@ def get_loc_techs_yaml_set(run, scenario_id, year):
                             technology]
                 dictify(loc_techs_yaml_set,param_list,'')
                 continue
-
         # Tracks which parameters have already been set (prioritized by year)
         unique_params = []
         # Loop over Parameters
@@ -235,6 +234,7 @@ def get_loc_techs_yaml_set(run, scenario_id, year):
             else:
                 unique_param = param.parameter.root+'.'+param.parameter.name
             if unique_param not in unique_params:
+                unique_params.append(unique_param)
                 if '%' in param.parameter.units:  # Calliope in decimal format
                     value = float(param.value) / 100
                 else:


### PR DESCRIPTION
Fixing issue where multiple years of params could be written to a loc_tech params YAML set