### PR TITLE
Set SSL cert required on celery

### DIFF
--- a/calliope_app/calliope_app/settings/prod.py
+++ b/calliope_app/calliope_app/settings/prod.py
@@ -1,10 +1,13 @@
 """
 Django settings for production deployment
 """
-from .base import *  # noqa
+import ssl
 import sys
 
+from .base import *  # noqa
+
 env = environ.Env()
+
 
 # GENERAL
 # ------------------------------------------------------------------------------
@@ -162,3 +165,9 @@ CELERY_RESULT_SERIALIZER = 'json'
 CELERY_TIMEZONE = TIME_ZONE if USE_TZ else None
 CELERY_TRACK_STARTED = True
 CELERYD_CONCURRENCY = 2
+CELERY_BROKER_USE_SSL = {
+    "ssl_cert_reqs": ssl.CERT_REQUIRED
+}
+CELERY_REDIS_BACKEND_USE_SSL = {
+    "ssl_cert_reqs": ssl.CERT_REQUIRED
+}


### PR DESCRIPTION
Celery broker is deployed with `encryption in transit`, ssl cert will be required for secure connection with `rediss://`